### PR TITLE
Kirill docker tags

### DIFF
--- a/.github/archive/__build_push_main_DEPRECATED.yml
+++ b/.github/archive/__build_push_main_DEPRECATED.yml
@@ -80,7 +80,6 @@ jobs:
         id: docker-compose-gen
         env:
           API_IMAGE_TAG: ${{ needs.docker-build-push.outputs.tag }}
-          SCRIPT_DIR: "scripts"
           DOCKER_DIR: "docker"
         run: |
           echo "Generate an updated docker-compose.yaml file with new tag..."

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: '08:00'

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -63,11 +63,7 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
           labels: |
             maintainer=https://github.com/deft1991
             org.opencontainers.image.title=RunPodStableDiffusion
@@ -104,7 +100,6 @@ jobs:
           DOCKER_DIR: "docker"
         run: |
           echo "Generate an updated docker-compose.yaml file with new tag..."
-          ./"$SCRIPT_DIR"/update_docker_image.sh "${API_IMAGE_NAME}:${API_IMAGE_TAG}"
           
           DOCKER_COMPOSE_FILE="$(yq -o=json '.' $DOCKER_DIR/compose.yaml)"
           echo "DOCKER_COMPOSE_FILE="$(echo "$DOCKER_COMPOSE_FILE")"" >> "$GITHUB_OUTPUT"
@@ -123,9 +118,10 @@ jobs:
       - name: Login to API instance and deploy a new image
         uses: appleboy/ssh-action@v1.0.0
         env:
+          API_IMAGE: ${{ env.DOCKER_USERNAME }}/${{ env.DOCKER_REPO }}:${{ needs.docker-build-push.outputs.tag }}
           DOCKER_COMPOSE_FILE: ${{ steps.docker-compose-gen.outputs.DOCKER_COMPOSE_FILE }}
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           ENV_FILE: ${{ secrets.ENV_FILE }}
           NGINX_403_FILE: ${{ steps.docker-compose-gen.outputs.NGINX_403_FILE }}
           NGINX_502_FILE: ${{ steps.docker-compose-gen.outputs.NGINX_502_FILE }}
@@ -138,7 +134,7 @@ jobs:
           key: ${{ secrets.API_KEY }}
           port: 22
           script_stop: true
-          envs: DOCKER_COMPOSE_FILE,ENV_FILE,NGINX_CONFIG_FILE,NGINX_INDEX_FILE,NGINX_403_FILE,NGINX_502_FILE,SRC_DIR,DOCKER_PASSWORD,DOCKER_USERNAME
+          envs: API_IMAGE,DOCKER_COMPOSE_FILE,ENV_FILE,NGINX_CONFIG_FILE,NGINX_INDEX_FILE,NGINX_403_FILE,NGINX_502_FILE,SRC_DIR,DOCKER_PASSWORD,DOCKER_USERNAME
           command_timeout: 30m
           script: |
             mkdir -p "${SRC_DIR}/proxy"
@@ -154,6 +150,9 @@ jobs:
             # echo $(echo "$ENV_FILE" | base64 -d) > .env
             echo "$ENV_FILE"
             echo "$ENV_FILE"  > .env
+            
+            # Remove API_IMAGE from the .env file
+            sed -i '/API_IMAGE/d' .env
             
             # Update docker compose file
             yq -p=json <<<"$DOCKER_COMPOSE_FILE" > compose.yaml

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -3,9 +3,14 @@ name: Develop Build and Deploy
 on:
   workflow_dispatch:
     inputs:
-      need-to-deploy:
+      deploy:
         default: false
         description: 'Deploy to an instance? By default do not deploy a new image to an instance(build and push only)'
+        required: false
+        type: boolean
+      tests:
+        default: true
+        description: 'Run tests'
         required: false
         type: boolean
   push:
@@ -22,6 +27,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    if: github.event.inputs.tests == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -87,7 +93,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: docker-build-push
-    if: github.event.inputs.need-to-deploy == 'true'
+    if: github.event.inputs.deploy == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Login to API instance and deploy a new image
         uses: appleboy/ssh-action@v1.0.0
         env:
-          API_IMAGE: ${{ env.DOCKER_USERNAME }}/${{ env.DOCKER_REPO }}:${{ needs.docker-build-push.outputs.tag }}
+          API_IMAGE: ${{ env.API_IMAGE_NAME }}:${{ needs.docker-build-push.outputs.tag }}
           DOCKER_COMPOSE_FILE: ${{ steps.docker-compose-gen.outputs.DOCKER_COMPOSE_FILE }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -69,7 +69,11 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,enable=true,priority=1000,prefix=sha-,suffix=,format=short
           labels: |
             maintainer=https://github.com/deft1991
             org.opencontainers.image.title=RunPodStableDiffusion

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -84,8 +84,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.API_IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.API_IMAGE_NAME }}:buildcache,mode=max
           context: .
           file: ${{ env.DOCKERFILE_PATH }}/${{ env.DOCKERFILE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -8,11 +8,6 @@ on:
         description: 'Deploy to an instance? By default do not deploy a new image to an instance(build and push only)'
         required: false
         type: boolean
-      tests:
-        default: true
-        description: 'Run tests'
-        required: false
-        type: boolean
   push:
     branches:
       - 'develop'
@@ -27,7 +22,6 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    if: github.event.inputs.tests == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,6 +32,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
+      
       - name: Test project
         run: gradle multi-starter-service:test
 

--- a/.github/workflows/build_push_main.yml
+++ b/.github/workflows/build_push_main.yml
@@ -47,10 +47,9 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
             type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
           labels: |
             maintainer=https://github.com/deft1991

--- a/.github/workflows/build_push_main.yml
+++ b/.github/workflows/build_push_main.yml
@@ -51,7 +51,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
           labels: |
             maintainer=https://github.com/deft1991
             org.opencontainers.image.title=RunPodStableDiffusion
@@ -108,21 +108,23 @@ jobs:
         uses: appleboy/ssh-action@v1.0.0
         env:
           DOCKER_COMPOSE_FILE: ${{ steps.docker-compose-gen.outputs.DOCKER_COMPOSE_FILE }}
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKER_TAG: ${{ steps.meta.outputs.tags }}
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           ENV_FILE: ${{ secrets.ENV_FILE }}
           NGINX_403_FILE: ${{ steps.docker-compose-gen.outputs.NGINX_403_FILE }}
           NGINX_502_FILE: ${{ steps.docker-compose-gen.outputs.NGINX_502_FILE }}
           NGINX_CONFIG_FILE: ${{ steps.docker-compose-gen.outputs.NGINX_CONFIG_FILE }}
           NGINX_INDEX_FILE: ${{ steps.docker-compose-gen.outputs.NGINX_INDEX_FILE }}
           SRC_DIR: "/home/ec2-user/watchman"
+          API_IMAGE: ${{ env.DOCKER_USERNAME }}/${{ env.DOCKER_REPO }}:${{ needs.docker-build-push.outputs.tag }}
         with:
           host: ${{ secrets.API_HOST }}
           username: ${{ secrets.API_USERNAME }}
           key: ${{ secrets.API_KEY }}
           port: 22
           script_stop: true
-          envs: DOCKER_COMPOSE_FILE,ENV_FILE,NGINX_CONFIG_FILE,NGINX_INDEX_FILE,NGINX_403_FILE,NGINX_502_FILE,SRC_DIR,DOCKER_PASSWORD,DOCKER_USERNAME
+          envs: API_IMAGE,DOCKER_COMPOSE_FILE,ENV_FILE,NGINX_CONFIG_FILE,NGINX_INDEX_FILE,NGINX_403_FILE,NGINX_502_FILE,SRC_DIR,DOCKER_PASSWORD,DOCKER_USERNAME
           command_timeout: 30m
           script: |
             mkdir -p "${SRC_DIR}/proxy"

--- a/.github/workflows/build_push_main.yml
+++ b/.github/workflows/build_push_main.yml
@@ -134,6 +134,8 @@ jobs:
             
             # Update creds
             echo "$ENV_FILE" | base64 -d > .env
+            # remove API_IMAGE from the .env file
+            sed -i '/API_IMAGE/d' .env
             
             # Update docker compose file
             yq -p=json <<<"$DOCKER_COMPOSE_FILE" > compose.yaml

--- a/.github/workflows/build_push_main.yml
+++ b/.github/workflows/build_push_main.yml
@@ -47,9 +47,6 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=ref,event=pr
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
             type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
           labels: |
             maintainer=https://github.com/deft1991

--- a/.github/workflows/build_push_main.yml
+++ b/.github/workflows/build_push_main.yml
@@ -84,7 +84,6 @@ jobs:
           DOCKER_DIR: "docker"
         run: |
           echo "Generate an updated docker-compose.yaml file with new tag..."
-          ./"$SCRIPT_DIR"/update_docker_image.sh "${API_IMAGE_NAME}:${API_IMAGE_TAG}"
           
           DOCKER_COMPOSE_FILE="$(yq -o=json '.' $DOCKER_DIR/compose.yaml)"
           echo "DOCKER_COMPOSE_FILE="$(echo "$DOCKER_COMPOSE_FILE")"" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
- Use git commit sha as the tag for the docker image.
- Add Dependabot to automatically create PR and bump GitHub action jobs to an actual version